### PR TITLE
Fix send email route path in tests

### DIFF
--- a/src/app/test/send-email.test.js
+++ b/src/app/test/send-email.test.js
@@ -1,5 +1,5 @@
 import { createMocks } from "node-mocks-http";
-import { POST as sendEmailRoute } from "../api/send-email/route";
+import { POST as sendEmailRoute } from "../api/send-email-nodemailer/route";
 import fetch from "node-fetch";
 
 jest.mock("node-fetch");


### PR DESCRIPTION
## Summary
- update send-email test to use the nodemailer route

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684000a8f4908329b3e921612dfcc9c3