### PR TITLE
Fix Upstash env var name

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ RECAPTCHA_SECRET_KEY=your_recaptcha_secret_key
 
 #Redis - Upstash
 UPSTASH_REDIS_REST_URL=your_url
-UPSTASH_REDIS_REST_TOKE=your_token
+UPSTASH_REDIS_REST_TOKEN=your_token
 
 # Configuration SMTP (Brevo)
 SMTP_HOST=smtp-relay.brevo.com


### PR DESCRIPTION
## Summary
- fix misspelled UPSTASH env var name in `.env.example`
- ensure file ends with a newline

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848237ba17c8329910c831052c868a9